### PR TITLE
cachelib 0.14.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,6 @@
 {% set name = "cachelib" %}
 {% set version = "0.14.0" %}
-{% set ignore_tests = " --ignore=tests/test_dynamodb_cache.py" %}
-{% set ignore_tests = ignore_tests + " --ignore=tests/test_mongodb_cache.py" %}
 
-# pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 61] Connection refused
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -22,8 +19,13 @@ requirements:
     - pip
     - setuptools
     - python
+    - flit-core <4
   run:
     - python
+
+# pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 61] Connection refused
+{% set ignore_tests = " --ignore=tests/test_dynamodb_cache.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_mongodb_cache.py" %}
 
 test:
   source_files:
@@ -54,7 +56,7 @@ about:
   description: A collection of cache libraries in the same API interface. Extracted from Werkzeug.
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE.rst
+  license_file: LICENSE.txt
   doc_url: https://cachelib.readthedocs.io
   dev_url: https://github.com/pallets-eco/cachelib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,16 @@
 {% set name = "cachelib" %}
-{% set version = "0.13.0" %}
+{% set version = "0.14.0" %}
+{% set ignore_tests = " --ignore=tests/test_dynamodb_cache.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_mongodb_cache.py" %}
 
+# pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 61] Connection refused
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 209d8996e3c57595bee274ff97116d1d73c4980b2fd9a34c7846cd07fd2e1a48
+  sha256: 73fedcadd0ba818fb2bb9f3c7cd5fcc2a71e86286f1842f55f28d500faee17f1
 
 build:
   number: 0
@@ -21,10 +24,6 @@ requirements:
     - python
   run:
     - python
-
-# pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 61] Connection refused
-{% set ignore_tests = " --ignore=tests/test_dynamodb_cache.py" %}
-{% set ignore_tests = ignore_tests + " --ignore=tests/test_mongodb_cache.py" %}
 
 test:
   source_files:


### PR DESCRIPTION
cachelib 0.14.0 

**Destination channel:** Defaults

### Links

- [PKG-15628]
- dev_url:        https://github.com/pallets-eco/cachelib/tree/0.14.0
- conda_forge:    https://github.com/conda-forge/cachelib-feedstock
- pypi:           https://pypi.org/project/cachelib/0.14.0
- pypi inspector: https://inspector.pypi.io/project/cachelib/0.14.0

### Explanation of changes:

- new version number


[PKG-15628]: https://anaconda.atlassian.net/browse/PKG-15628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ